### PR TITLE
Fixed LogicParser to correctly read its own output

### DIFF
--- a/src/edu/uw/easysrl/semantics/ConnectiveSentence.java
+++ b/src/edu/uw/easysrl/semantics/ConnectiveSentence.java
@@ -90,6 +90,7 @@ public class ConnectiveSentence extends Sentence {
 
 	@Override
 	void toString(final StringBuilder result, final VariableNames varToName) {
+		result.append("(");
 		boolean isFirst = true;
 		for (final Sentence child : children) {
 			if (isFirst) {
@@ -99,6 +100,7 @@ public class ConnectiveSentence extends Sentence {
 			}
 			child.toString(result, varToName);
 		}
+		result.append(")");
 	}
 
 	@Override

--- a/src/edu/uw/easysrl/util/Util.java
+++ b/src/edu/uw/easysrl/util/Util.java
@@ -233,9 +233,9 @@ public class Util {
 		int openBrackets = 0;
 
 		for (int i = 0; i < haystack.length(); i++) {
-			if (haystack.charAt(i) == '(' || haystack.charAt(i) == '[') {
+			if (haystack.charAt(i) == '(' || haystack.charAt(i) == '[' || haystack.charAt(i) == '{') {
 				openBrackets++;
-			} else if (haystack.charAt(i) == ')' || haystack.charAt(i) == ']') {
+			} else if (haystack.charAt(i) == ')' || haystack.charAt(i) == ']' || haystack.charAt(i) == '}') {
 				openBrackets--;
 			} else if (openBrackets == 0) {
 				for (int j = 0; j < needles.length(); j++) {


### PR DESCRIPTION
This fixed LogicParser to correctly read its own output as well as the format used for specifying lexicons. It also adds parentheses to the String representation of ConnectiveSentences.

NOTE: I have not update easysrl.jar because I am not sure how that was done exactly.