### PR TITLE
Fix semantic bugs

### DIFF
--- a/src/edu/uw/easysrl/semantics/lexicon/CopulaLexicon.java
+++ b/src/edu/uw/easysrl/semantics/lexicon/CopulaLexicon.java
@@ -6,9 +6,12 @@ import java.util.Optional;
 import edu.uw.easysrl.dependencies.Coindexation;
 import edu.uw.easysrl.dependencies.ResolvedDependency;
 import edu.uw.easysrl.semantics.AtomicSentence;
+import edu.uw.easysrl.semantics.Constant;
 import edu.uw.easysrl.semantics.LambdaExpression;
 import edu.uw.easysrl.semantics.Logic;
+import edu.uw.easysrl.semantics.SemanticType;
 import edu.uw.easysrl.semantics.Variable;
+import edu.uw.easysrl.semantics.SemanticType.ComplexSemanticType;
 import edu.uw.easysrl.syntax.grammar.Category;
 import edu.uw.easysrl.syntax.grammar.Preposition;
 import edu.uw.easysrl.syntax.grammar.SyntaxTreeNode;
@@ -53,7 +56,14 @@ public class CopulaLexicon extends Lexicon {
 				statement = new AtomicSentence(getPrepositionPredicate(deps, 0, parse), vars.get(0), vars.get(1), head);
 			} else {
 				// S\NP/NP
-				statement = new AtomicSentence(equals, vars.get(0), vars.get(1), head);
+				SemanticType type = SemanticType.T;
+				type = ComplexSemanticType.make(head.getType(), type);
+				type = ComplexSemanticType.make(vars.get(1).getType(), type);
+				type = ComplexSemanticType.make(vars.get(0).getType(), type);
+				
+				Constant pred = new Constant("eq", type);
+				
+				statement = new AtomicSentence(pred, vars.get(0), vars.get(1), head);
 			}
 		}
 

--- a/src/edu/uw/easysrl/semantics/lexicon/NumbersLexicon.java
+++ b/src/edu/uw/easysrl/semantics/lexicon/NumbersLexicon.java
@@ -20,7 +20,7 @@ public class NumbersLexicon extends Lexicon {
 		if (category == Category.ADJECTIVE && pos.equals("CD")) {
 			// Lots of room for improvement here...
 			return LogicParser.fromString("#y#p#x.p(x) & eq(size(x), y)", Category.valueOf("(N/N)/NP")).apply(
-					new Constant(getLemma(word, pos, parse, wordIndex), SemanticType.makeFromCategory(Category.N)));
+					new Constant(getLemma(word, pos, parse, wordIndex), SemanticType.makeFromCategory(Category.NP)));
 		}
 
 		return null;


### PR DESCRIPTION
This fixes two bugs in the default lexicon used for creating semantics. Two instances of the "eq" predicate did not type-check correctly:

1. When used in a numerical expression like "3 rectangles", eq had the type \<t,\<e,t\>\>, but 3 was given the type:\<e,t\> so the expression : "eq(size(x), 3)" failed to typecheck. eq should instead be "\<t,\<\<e,t>,e\>\>"

2. In copular expressions like "What animal is this ?" -> #e.eq(this,sk(#x.(animal(x)&eq(x,ANSWER))),e). The outer "eq" was given the type \<e,\<e,t\>\>, but should be \<e,\<e,\<ev,t\>\>\>