### PR TITLE
fixed a bug with OperatorSentenceParser

### DIFF
--- a/src/edu/uw/easysrl/semantics/LogicParser.java
+++ b/src/edu/uw/easysrl/semantics/LogicParser.java
@@ -161,7 +161,7 @@ public abstract class LogicParser {
 		private Operator getOp(final String opString) {
 			for (final Operator op : OperatorSentence.Operator.values()) {
 				// \not p(x)
-				if (opString.equals(op.toString()) || opString.equals(op.asString())) {
+				if (opString.equalsIgnoreCase("\\" + op.toString()) || opString.equals(op.asString())) {
 					return op;
 				}
 			}


### PR DESCRIPTION
This fixes a bug in OperatorSentenceParser that I introduced in cfc04df. The logic parser was not working when written in the format "\not p(x)"