### PR TITLE
fixed bug in Combinator

### DIFF
--- a/src/edu/uw/easysrl/syntax/grammar/Combinator.java
+++ b/src/edu/uw/easysrl/syntax/grammar/Combinator.java
@@ -5,6 +5,7 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -162,6 +163,10 @@ public abstract class Combinator {
 			}
 		}
 
+		if (result.size() == 0) {
+			return Collections.emptyList();
+		}
+		
 		return result;
 	}
 


### PR DESCRIPTION
fixed bug in Combinator which adds pointers to unique empty trees to the rule cache when a rule produces no productions. This solves a problem where memory usage was spiralling upwards.