### PR TITLE
Make it possible to use getLemma outside of EasySRL code

### DIFF
--- a/src/edu/uw/easysrl/semantics/lexicon/Lexicon.java
+++ b/src/edu/uw/easysrl/semantics/lexicon/Lexicon.java
@@ -51,7 +51,7 @@ public abstract class Lexicon {
 	 * Gets a lemma for a phrase. Multiword phrases are collapsed into a single token. If a parse is provided, it will
 	 * collapse verb-particle constructions.
 	 */
-	String getLemma(final String word, final String pos, final Optional<CCGandSRLparse> parse, final int wordIndex) {
+	public String getLemma(final String word, final String pos, final Optional<CCGandSRLparse> parse, final int wordIndex) {
 		String lemma = word == null ? null : MorphaStemmer.stemToken(word.toLowerCase().replaceAll(" ", "_"), pos);
 		if (parse.isPresent()) {
 			final List<ResolvedDependency> deps = parse.get().getOrderedDependenciesAtPredicateIndex(wordIndex);


### PR DESCRIPTION
I'm trying to use EasySRL as a library for some other code I'm writing.  I'm adding new lexica, and I would like to access Lexicon.getLemma from my lexica, which are defined in packages outside of easysrl code.  This makes it possible.